### PR TITLE
Remove toml dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,3 @@ serde_json = "1.0.81"
 tokio = { version = "1.19.2", default-features = false, features = ["rt-multi-thread"] }
 futures = { version = "0.3.21", default-features = false, features = ["std"] }
 mdbook-preprocessor-boilerplate = "0.1.1"
-toml = "0.5.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,15 +93,18 @@ impl Preprocessor for KrokiPreprocessor {
     fn run(&self, ctx: &PreprocessorContext, mut book: Book) -> Result<Book> {
         let endpoint = if let Some(config) = ctx.config.get_preprocessor(self.name()) {
             match config.get("endpoint") {
-                Some(toml::value::Value::String(value)) => {
-                    let mut url = value.clone();
-                    if !url.ends_with("/") {
-                        url.push_str("/");
+                Some(v) => {
+                    if let Some(s) = v.as_str() {
+                        let mut url = s.to_string();
+                        if !url.ends_with("/") {
+                            url.push_str("/");
+                        }
+                        url
+                    } else {
+                        bail!("endpoint must be a string")
                     }
-                    url
                 }
                 None => "https://kroki.io/".to_string(),
-                Some(_) => bail!("endpoint must be a string")
             }
         } else {
             "https://kroki.io/".to_string()


### PR DESCRIPTION
Resolves an incompatibility between toml@0.7 and mdbook@latest, by avoiding the toml dependency entirely.